### PR TITLE
added infeasible turn warning

### DIFF
--- a/ADRpy/constraintanalysis.py
+++ b/ADRpy/constraintanalysis.py
@@ -1067,6 +1067,14 @@ class AircraftConcept:
         trnspeed_mpstas = co.kts2mps(self.turnspeed_ktas)
         if feasibleonly:
             pw_trn_wpn = tw2pw(twreq['turnfeasible'], trnspeed_mpstas, self.etaprop_turn)
+            if all(np.isnan(pw_trn_wpn)):
+                nanmsg = "All turns are infeasible for the given load factor, speed, and wing loadings."
+                warnings.warn(nanmsg, RuntimeWarning)
+            elif any(np.isnan(pw_trn_wpn)):
+                # Find maximum feasible wing loading
+                maxfeasiblewl = max([wl for wl, ptw in zip(wingloadinglist_pa, pw_trn_wpn) if not np.isnan(ptw)])
+                nanmsg = "Turns only feasible up to wingloading_pa = " + str(maxfeasiblewl)
+                warnings.warn(nanmsg, RuntimeWarning)
         else:
             pw_trn_wpn = tw2pw(twreq['turn'], trnspeed_mpstas, self.etaprop_turn)
         pw_trn_hpkg = co.wn2hpkg(pw_trn_wpn)

--- a/ADRpy/constraintanalysis.py
+++ b/ADRpy/constraintanalysis.py
@@ -1070,11 +1070,6 @@ class AircraftConcept:
             if all(np.isnan(pw_trn_wpn)):
                 nanmsg = "All turns are infeasible for the given load factor, speed, and wing loadings."
                 warnings.warn(nanmsg, RuntimeWarning)
-            elif any(np.isnan(pw_trn_wpn)):
-                # Find maximum feasible wing loading
-                maxfeasiblewl = max([wl for wl, ptw in zip(wingloadinglist_pa, pw_trn_wpn) if not np.isnan(ptw)])
-                nanmsg = "Turns only feasible up to wingloading_pa = " + str(maxfeasiblewl)
-                warnings.warn(nanmsg, RuntimeWarning)
         else:
             pw_trn_wpn = tw2pw(twreq['turn'], trnspeed_mpstas, self.etaprop_turn)
         pw_trn_hpkg = co.wn2hpkg(pw_trn_wpn)


### PR DESCRIPTION
This commit adds a warning when infeasible values are encountered and removed during the required power calculation for turns. This allows the user to quickly identify problems with the design brief or wing loading range.

This image is an example of the warning as it occurs in the [constraints analysis documentation notebook](https://github.com/sobester/ADRpy/blob/master/docs/ADRpy/notebooks/Constraint%20analysis%20of%20a%20single%20engine%20piston%20prop.ipynb). Although it doesn't look nice, it does give the user important debug information if they are developing a suitable brief.

![image](https://user-images.githubusercontent.com/4119878/67485144-62b80b00-f661-11e9-95b0-4d57164a2271.png)

All that being said, it may not be a necessary warning and could imply worse consequences than are actually present.
