### PR TITLE
remove pypi-publisher from install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
     all_reqs = f.read().split('\n')
 
-install_requires = [x.strip() for x in all_reqs if 'git+' not in x]
+install_requires = [x.strip() for x in all_reqs if 'git+' not in x and x != 'pypi-publisher']
 dependency_links = [x.strip().replace('git+', '') for x in all_reqs if x.startswith('git+')]
 
 setup(


### PR DESCRIPTION
The motivation for removing `pypi-publisher` from install requirements comes from the fact that `pypi-publisher` depends on an outdated version of `gitpython==0.3.6` that breaks other packages available on pypi like `mkdocs-git-revision-date-localized-plugin`.  Your ADRpy package has been an awesome enabler for our research and I hope you'll be willing to entertain this minor change.